### PR TITLE
Return struct of DNS Records

### DIFF
--- a/dreamhostapi.go
+++ b/dreamhostapi.go
@@ -80,13 +80,20 @@ func submitDreamhostCommand(command map[string]string, apiKey string) (string, e
 }
 
 // getDNSRecords gets the DNS records from the Dreamhost API
-func GetDNSRecords(apiKey string) (string, error) {
+func GetDNSRecords(apiKey string) (DnsRecordsJSON, error) {
 	command := map[string]string{"cmd": "dns-list_records"}
 	dnsRecords, err := submitDreamhostCommand(command, apiKey)
 	if err != nil {
 		return "", err
 	}
-	return dnsRecords, err
+	var records DnsRecordsJSON
+	err = json.Unmarshal([]byte(dnsRecords), &records)
+	if err != nil {
+		errorString := fmt.Sprintf("Unable to unmashal the JSON from Dreamhost. err is: %n", err)
+		conditionalLog(errorString, *verbose)
+		fileLogger.Fatal(errorString)
+	}
+	return records, err
 }
 
 // conditionalLog will print a log to the console if logActive true

--- a/dreamhostapi.go
+++ b/dreamhostapi.go
@@ -19,9 +19,20 @@ func (apiErr DreamhostAPIError) Error() string {
 
 // dnsRecordsJSON holds the JSON returned by the Dreamhost API
 type DnsRecordsJSON struct {
-	Data []map[string]string `json:"data"`
+	Data []DnsRecord `json:"data"`
 }
 
+// DnsRecord is a DNS Record on Dreamhost
+type DnsRecord struct {
+	Record     string // the URL
+	Zone       string // This is the base of the URL. If Record is www.google.com, Zone is google.com
+	Value      string // this is what the zone points to - usually IP address
+	Editable   string // 0 or 1 value, but comes back as a string
+	ZoneType   string `json:"type"` // zone type, eg A, AAA, MX, etc 
+	Comment    string // comment that can be added to a record
+	AccountId string `json:"account_id"` // the account associated with this record
+}
+map[string]string
 // commandResult for when you only care about the result
 type commandResult struct {
 	Data   string `json:"data"`


### PR DESCRIPTION
Instead of returning the JSON for the app using the lib to interpret, return a struct of DNS records. Put this more in line with how I'm returning the statuses.